### PR TITLE
fix context missing after valdiate once

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -15,11 +15,12 @@ class Validator
 	{
 		$attribute = $this->registrar->getAttribute($parameters[0]);
 
-		if (array_key_exists(1, $parameters)) {
-			$attribute->setContext($parameters[1]);
-		}
-
 		foreach ((array) $value as $item) {
+
+			if (array_key_exists(1, $parameters)) {
+				$attribute->setContext($parameters[1]);
+			}
+
 			if ( ! $attribute->hasKey($item)) {
 				return false;
 			}


### PR DESCRIPTION
使用 hasKey() 之後
context會被改成null

導致value[1],value[2],value[3]...後面的驗證失效